### PR TITLE
Abstract out a Progress indicator

### DIFF
--- a/TestRunner.Lib/Domain.fs
+++ b/TestRunner.Lib/Domain.fs
@@ -131,3 +131,22 @@ type TestFailure =
         | TestFailure.TestFailed f
         | TestFailure.SetUpFailed f
         | TestFailure.TearDownFailed f -> f.Name
+
+/// Represents the result of a test that didn't fail.
+[<RequireQualifiedAccess>]
+type TestMemberSuccess =
+    /// The test passed.
+    | Ok
+    /// We didn't run the test, because it's [<Ignore>].
+    | Ignored of reason : string option
+    /// We didn't run the test, because it's [<Explicit>].
+    | Explicit of reason : string option
+
+/// Represents the failure of a test.
+[<RequireQualifiedAccess>]
+type TestMemberFailure =
+    /// We couldn't run this test because it was somehow malformed in a way we detected up front.
+    | Malformed of reasons : string list
+    /// We tried to run the test, but it failed. (A single test can fail many times, e.g. if it failed and also
+    /// the tear-down logic failed afterwards.)
+    | Failed of TestFailure list

--- a/TestRunner.Lib/SurfaceBaseline.txt
+++ b/TestRunner.Lib/SurfaceBaseline.txt
@@ -73,6 +73,12 @@ TestRunner.FixtureRunResults.get_OtherFailures [method]: unit -> TestRunner.User
 TestRunner.FixtureRunResults.get_SuccessCount [method]: unit -> int
 TestRunner.FixtureRunResults.OtherFailures [property]: [read-only] TestRunner.UserMethodFailure list
 TestRunner.FixtureRunResults.SuccessCount [property]: [read-only] int
+TestRunner.ITestProgress - interface with 5 member(s)
+TestRunner.ITestProgress.OnTestFailed [method]: string -> TestRunner.TestMemberFailure -> unit
+TestRunner.ITestProgress.OnTestFixtureStart [method]: string -> int -> unit
+TestRunner.ITestProgress.OnTestMemberFinished [method]: string -> unit
+TestRunner.ITestProgress.OnTestMemberSkipped [method]: string -> unit
+TestRunner.ITestProgress.OnTestMemberStart [method]: string -> unit
 TestRunner.Match inherit obj, implements TestRunner.Match System.IEquatable, System.Collections.IStructuralEquatable, TestRunner.Match System.IComparable, System.IComparable, System.Collections.IStructuralComparable - union type with 2 cases
 TestRunner.Match+Contains inherit TestRunner.Match
 TestRunner.Match+Contains.get_Item [method]: unit -> string
@@ -171,7 +177,7 @@ TestRunner.TestFixture.TearDown [property]: [read-only] System.Reflection.Method
 TestRunner.TestFixture.Tests [property]: [read-only] TestRunner.SingleTestMethod list
 TestRunner.TestFixtureModule inherit obj
 TestRunner.TestFixtureModule.parse [static method]: System.Type -> TestRunner.TestFixture
-TestRunner.TestFixtureModule.run [static method]: (TestRunner.TestFixture -> TestRunner.SingleTestMethod -> bool) -> TestRunner.TestFixture -> TestRunner.FixtureRunResults
+TestRunner.TestFixtureModule.run [static method]: TestRunner.ITestProgress -> (TestRunner.TestFixture -> TestRunner.SingleTestMethod -> bool) -> TestRunner.TestFixture -> TestRunner.FixtureRunResults
 TestRunner.TestKind inherit obj, implements TestRunner.TestKind System.IEquatable, System.Collections.IStructuralEquatable - union type with 3 cases
 TestRunner.TestKind+Data inherit TestRunner.TestKind
 TestRunner.TestKind+Data.get_Item [method]: unit -> obj list list
@@ -236,6 +242,8 @@ TestRunner.TestMemberSuccess.NewExplicit [static method]: string option -> TestR
 TestRunner.TestMemberSuccess.NewIgnored [static method]: string option -> TestRunner.TestMemberSuccess
 TestRunner.TestMemberSuccess.Ok [static property]: [read-only] TestRunner.TestMemberSuccess
 TestRunner.TestMemberSuccess.Tag [property]: [read-only] int
+TestRunner.TestProgress inherit obj
+TestRunner.TestProgress.toStderr [static method]: unit -> TestRunner.ITestProgress
 TestRunner.UserMethodFailure inherit obj, implements TestRunner.UserMethodFailure System.IEquatable, System.Collections.IStructuralEquatable - union type with 2 cases
 TestRunner.UserMethodFailure+ReturnedNonUnit inherit TestRunner.UserMethodFailure
 TestRunner.UserMethodFailure+ReturnedNonUnit.get_name [method]: unit -> string

--- a/TestRunner.Lib/TestProgress.fs
+++ b/TestRunner.Lib/TestProgress.fs
@@ -1,0 +1,45 @@
+namespace TestRunner
+
+open System
+
+/// Represents something which knows how to report progress through a test suite.
+/// Note that we don't guarantee anything about parallelism; you must make sure
+/// all implementations are safe to run concurrently.
+type ITestProgress =
+    /// Called just before we start executing the setup logic for the given test fixture.
+    /// We tell you how many test methods there are in the fixture.
+    abstract OnTestFixtureStart : name : string -> testCount : int -> unit
+    /// Called just before we start executing the test(s) indicated by a particular method.
+    abstract OnTestMemberStart : name : string -> unit
+    /// Called when a test fails. (This may be called repeatedly with the same `name`, e.g. if the test
+    /// is run multiple times with different combinations of test data.)
+    abstract OnTestFailed : name : string -> failure : TestMemberFailure -> unit
+    /// Called when we've finished every test indicated by a particular method. (The test may have been run
+    /// multiple times, e.g. with different combinations of test data.)
+    abstract OnTestMemberFinished : name : string -> unit
+    /// Called when we decide not to run the test(s) indicated by a particular method (e.g. because it's
+    /// marked [<Explicit>]).
+    abstract OnTestMemberSkipped : name : string -> unit
+
+/// Methods for constructing specific ITestProgress objects.
+[<RequireQualifiedAccess>]
+module TestProgress =
+    /// An ITestProgress which logs to stderr.
+    let toStderr () : ITestProgress =
+        { new ITestProgress with
+            member _.OnTestFixtureStart name testCount =
+                let plural = if testCount = 1 then "" else "s"
+                Console.Error.WriteLine $"Running test fixture: %s{name} (%i{testCount} test%s{plural} to run)"
+
+            member _.OnTestMemberStart name =
+                Console.Error.WriteLine $"Running test: %s{name}"
+
+            member _.OnTestFailed name failure =
+                Console.Error.WriteLine $"Test failed: %O{failure}"
+
+            member _.OnTestMemberFinished name =
+                Console.Error.WriteLine $"Finished test %s{name}"
+
+            member _.OnTestMemberSkipped name =
+                Console.Error.WriteLine $"Skipping test due to filter: %s{name}"
+        }

--- a/TestRunner.Lib/TestRunner.Lib.fsproj
+++ b/TestRunner.Lib/TestRunner.Lib.fsproj
@@ -34,6 +34,7 @@
     </ItemGroup>
   <ItemGroup>
     <PackageReference Include="WoofWare.PrattParser" Version="0.1.2" />
+    <PackageReference Update="FSharp.Core" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/TestRunner.Lib/TestRunner.Lib.fsproj
+++ b/TestRunner.Lib/TestRunner.Lib.fsproj
@@ -23,6 +23,7 @@
       <Compile Include="Domain.fs" />
       <Compile Include="Filter.fs" />
       <Compile Include="SingleTestMethod.fs" />
+      <Compile Include="TestProgress.fs" />
       <Compile Include="TestFixture.fs" />
       <None Include="..\README.md">
         <Pack>True</Pack>

--- a/TestRunner.Lib/version.json
+++ b/TestRunner.Lib/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1",
+  "version": "0.2",
   "publicReleaseRefSpec": null,
   "pathFilters": [
     "./",

--- a/nix/deps.nix
+++ b/nix/deps.nix
@@ -23,6 +23,11 @@
   })
   (fetchNuGet {
     pname = "FSharp.Core";
+    version = "6.0.0";
+    sha256 = "1hjhvr39c1vpgrdmf8xln5q86424fqkvy9nirkr29vl2461d2039";
+  })
+  (fetchNuGet {
+    pname = "FSharp.Core";
     version = "8.0.300";
     sha256 = "158xxr9hnhz2ibyzzp2d249angvxfc58ifflm4g3hz8qx9zxaq04";
   })


### PR DESCRIPTION
This is so that the console runner can depend on e.g. Spectre.Console without polluting the library.