### PR TITLE
Stop throwing on unrecognised exceptions

### DIFF
--- a/WoofWare.NUnitTestRunner.Lib/TestFixture.fs
+++ b/WoofWare.NUnitTestRunner.Lib/TestFixture.fs
@@ -168,8 +168,6 @@ module TestFixture =
                 | "NUnit.Framework.IgnoreException" -> Ok (Some (TestMemberSuccess.Ignored (Option.ofObj exc.Message)))
                 | "NUnit.Framework.InconclusiveException" ->
                     Ok (Some (TestMemberSuccess.Inconclusive (Option.ofObj exc.Message)))
-                | s when s.StartsWith ("NUnit.Framework.", StringComparison.Ordinal) ->
-                    failwith $"Unrecognised special exception: %s{s}"
                 | _ -> Error orig
             | Error orig -> Error orig
 


### PR DESCRIPTION
They'll already fail the test anyway; no need to destroy the runner.