### PR TITLE
Properly exclude test project

### DIFF
--- a/WoofWare.NUnitTestRunner/version.json
+++ b/WoofWare.NUnitTestRunner/version.json
@@ -5,7 +5,7 @@
   ],
   "pathFilters": [
     "./",
-    "^./WoofWare.NUnitTestRunner.Test",
+    ":^./WoofWare.NUnitTestRunner.Test",
     ":/WoofWare.NUnitTestRunner.Lib",
     ":/Directory.Build.props",
     ":/README.md"

--- a/WoofWare.NUnitTestRunner/version.json
+++ b/WoofWare.NUnitTestRunner/version.json
@@ -5,7 +5,7 @@
   ],
   "pathFilters": [
     "./",
-    ":^./WoofWare.NUnitTestRunner.Test",
+    ":^WoofWare.NUnitTestRunner.Test",
     ":/WoofWare.NUnitTestRunner.Lib",
     ":/Directory.Build.props",
     ":/README.md"


### PR DESCRIPTION
Docs at https://github.com/dotnet/Nerdbank.GitVersioning/blob/976fc101715546380c2f8bb8abef83fb2bb84dea/doc/pathFilters.md suggest the `:` prefix is actually required here.