### PR TITLE
Switch to Lychee

### DIFF
--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -168,7 +168,7 @@ jobs:
       - name: Enable Nix cache
         uses: DeterminateSystems/magic-nix-cache-action@1828eb4e5414b8dfe36daae53ea3e4b8c3fdec7a
       - name: Run link checker
-        run: nix develop --command markdown-link-check README.md
+        run: nix develop --command lychee README.md
 
   flake-check:
     name: Check flake

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1774610258,
-        "narHash": "sha256-HaThtroVD9wRdx7KQk0B75JmFcXlMUoEdDFNOMOlsOs=",
+        "lastModified": 1775126147,
+        "narHash": "sha256-J0dZU4atgcfo4QvM9D92uQ0Oe1eLTxBVXjJzdEMQpD0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "832efc09b4caf6b4569fbf9dc01bec3082a00611",
+        "rev": "8d8c1fa5b412c223ffa47410867813290cdedfef",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -63,7 +63,7 @@
           packages = [
             dotnet-sdk
             pkgs.alejandra
-            pkgs.nodePackages.markdown-link-check
+            pkgs.lychee
             pkgs.shellcheck
             pkgs.xmlstarlet
           ];


### PR DESCRIPTION
markdown-link-check is no longer packaged in nixpkgs.