### PR TITLE
Fix race losing concurrent test failures

### DIFF
--- a/WoofWare.NUnitTestRunner.Lib/TestFixture.fs
+++ b/WoofWare.NUnitTestRunner.Lib/TestFixture.fs
@@ -591,7 +591,7 @@ module TestFixture =
 
                                         match result with
                                         | Error failure ->
-                                            testFailures.Add (failure, report)
+                                            lock testFailures (fun () -> testFailures.Add (failure, report))
                                             progress.OnTestFailed test.Name failure
                                         | Ok result ->
                                             Interlocked.Increment testSuccess |> ignore<int>

--- a/WoofWare.NUnitTestRunner/WoofWare.NUnitTestRunner.Test/TestFixtureRunner.fs
+++ b/WoofWare.NUnitTestRunner/WoofWare.NUnitTestRunner.Test/TestFixtureRunner.fs
@@ -1,0 +1,64 @@
+namespace WoofWare.NUnitTestRunner.Test
+
+open NUnit.Framework
+open FsUnitTyped
+open WoofWare.NUnitTestRunner
+
+/// A module deliberately carrying no NUnit attributes: NUnit must not discover it, because every test in it
+/// fails. Instead, TestFixtureRunner drives it through TestFixture.run.
+module ManyFailuresFixture =
+    /// Lets us name this module's compiled Type via typeof.
+    type Marker = class end
+
+    let cases : int list = List.init 1000 id
+
+    let alwaysFails (i : int) : unit =
+        ignore i
+        failwith "deliberate failure"
+
+[<TestFixture>]
+module TestFixtureRunner =
+
+    let private noOpProgress =
+        { new ITestProgress with
+            member _.OnTestFixtureStart _ _ = ()
+            member _.OnTestFixtureSkipped _ _ = ()
+            member _.OnTestMemberStart _ = ()
+            member _.OnTestFailed _ _ = ()
+            member _.OnTestMemberFinished _ = ()
+            member _.OnTestMemberSkipped _ = ()
+        }
+
+    [<Test>]
+    let ``Failures reported concurrently are all retained`` () =
+        let moduleType = typeof<ManyFailuresFixture.Marker>.DeclaringType
+
+        let testMethod = moduleType.GetMethod (nameof ManyFailuresFixture.alwaysFails)
+
+        let test : SingleTestMethod =
+            {
+                Method = testMethod
+                Kind = TestKind.Source [ nameof ManyFailuresFixture.cases ]
+                Modifiers = []
+                Categories = []
+                Repeat = None
+                Combinatorial = None
+                Parallelize = None
+            }
+
+        let fixture =
+            { TestFixture.Empty moduleType None [] [] with
+                Tests = [ test ]
+            }
+
+        use contexts = TestContexts.Empty ()
+        use par = new ParallelQueue (Some 16, None)
+
+        let results =
+            (TestFixture.run contexts par noOpProgress (fun _ _ -> true) fixture).Result
+
+        let results = results |> List.exactlyOne
+        results.OtherFailures |> shouldBeEmpty
+        results.Success |> shouldBeEmpty
+
+        results.Failed |> List.length |> shouldEqual ManyFailuresFixture.cases.Length

--- a/WoofWare.NUnitTestRunner/WoofWare.NUnitTestRunner.Test/WoofWare.NUnitTestRunner.Test.fsproj
+++ b/WoofWare.NUnitTestRunner/WoofWare.NUnitTestRunner.Test/WoofWare.NUnitTestRunner.Test.fsproj
@@ -9,6 +9,7 @@
     <ItemGroup>
         <Compile Include="EmbeddedResource.fs" />
         <Compile Include="TestFilter.fs" />
+        <Compile Include="TestFixtureRunner.fs" />
         <Compile Include="TestList.fs" />
         <Compile Include="TestSurface.fs" />
         <Compile Include="TestSynchronizationContext.fs" />


### PR DESCRIPTION
## Summary

Review finding (P1): parallel test continuations call `testFailures.Add` concurrently, but `ResizeArray` is not thread-safe, so failures could be silently dropped from `FixtureRunResults` and hence from the TRX report. In the worst case a run whose only failure was dropped would report success.

The `successes` collection right next to it was already protected with `lock`; this applies the same discipline to `testFailures`.

## Test

Added a regression test that drives a 1000-case always-failing fixture through `TestFixture.run` in-process with a parallel queue and asserts every failure is retained. Against the unfixed code it failed immediately (992/1000 failures retained); with the fix it passed 5/5 consecutive runs.

The sample fixture deliberately carries no NUnit attributes so the NUnit adapter never discovers it; only the in-process driver runs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)