### PR TITLE
Don't run fixture lifecycle when the filter selects no tests

### DIFF
--- a/WoofWare.NUnitTestRunner.Lib/TestFixture.fs
+++ b/WoofWare.NUnitTestRunner.Lib/TestFixture.fs
@@ -495,6 +495,26 @@ module TestFixture =
         : FixtureRunResults Task
         =
         task {
+            let testsToRun =
+                tests.Tests
+                |> List.filter (fun test ->
+                    if filter tests test then
+                        true
+                    else
+                        progress.OnTestMemberSkipped test.Name
+                        false
+                )
+
+            if testsToRun.IsEmpty then
+                // No tests are selected, so the fixture's lifecycle methods must not run either.
+                return
+                    {
+                        Failed = []
+                        Success = []
+                        OtherFailures = []
+                    }
+            else
+
             let! running = par.StartTestFixture tests
             progress.OnTestFixtureStart name tests.Tests.Length
 
@@ -560,14 +580,7 @@ module TestFixture =
                     // Don't run any tests if setup failed.
                     Task.FromResult ()
                 | Ok _ ->
-                    tests.Tests
-                    |> Seq.filter (fun test ->
-                        if filter tests test then
-                            true
-                        else
-                            progress.OnTestMemberSkipped test.Name
-                            false
-                    )
+                    testsToRun
                     |> Seq.map (fun test ->
                         task {
                             let testSuccess = ref 0

--- a/WoofWare.NUnitTestRunner/WoofWare.NUnitTestRunner.Test/TestRunFiltering.fs
+++ b/WoofWare.NUnitTestRunner/WoofWare.NUnitTestRunner.Test/TestRunFiltering.fs
@@ -1,0 +1,80 @@
+namespace WoofWare.NUnitTestRunner.Test
+
+open System.Threading
+open NUnit.Framework
+open FsUnitTyped
+open WoofWare.NUnitTestRunner
+
+/// A module deliberately carrying no NUnit attributes: NUnit must not discover it, because its lifecycle methods
+/// fail. Instead, TestRunFiltering drives it through TestFixture.run.
+module ExcludedByFilterFixture =
+    /// Lets us name this module's compiled Type via typeof.
+    type Marker = class end
+
+    let oneTimeSetUpRunCount = ref 0
+    let oneTimeTearDownRunCount = ref 0
+
+    let oneTimeSetUp () : unit =
+        Interlocked.Increment oneTimeSetUpRunCount |> ignore<int>
+        failwith "deliberately failing one-time setup"
+
+    let oneTimeTearDown () : unit =
+        Interlocked.Increment oneTimeTearDownRunCount |> ignore<int>
+        failwith "deliberately failing one-time tear-down"
+
+    let someTest () : unit = ()
+
+[<TestFixture>]
+module TestRunFiltering =
+
+    [<Test>]
+    let ``A fixture none of whose tests are selected does not run its lifecycle methods`` () =
+        let moduleType = typeof<ExcludedByFilterFixture.Marker>.DeclaringType
+
+        let test : SingleTestMethod =
+            {
+                Method = moduleType.GetMethod (nameof ExcludedByFilterFixture.someTest)
+                Kind = TestKind.Single
+                Modifiers = []
+                Categories = []
+                Repeat = None
+                Combinatorial = None
+                Parallelize = None
+            }
+
+        let fixture =
+            { TestFixture.Empty moduleType None [] [] with
+                Tests = [ test ]
+                OneTimeSetUp = Some (moduleType.GetMethod (nameof ExcludedByFilterFixture.oneTimeSetUp))
+                OneTimeTearDown = Some (moduleType.GetMethod (nameof ExcludedByFilterFixture.oneTimeTearDown))
+            }
+
+        use contexts = TestContexts.Empty ()
+        use par = new ParallelQueue (None, None)
+
+        let skipped = ResizeArray ()
+
+        let progress =
+            { new ITestProgress with
+                member _.OnTestFixtureStart _ _ = ()
+                member _.OnTestFixtureSkipped _ _ = ()
+                member _.OnTestMemberStart _ = ()
+                member _.OnTestFailed _ _ = ()
+                member _.OnTestMemberFinished _ = ()
+
+                member _.OnTestMemberSkipped name =
+                    lock skipped (fun () -> skipped.Add name)
+            }
+
+        let results =
+            (TestFixture.run contexts par progress (fun _ _ -> false) fixture).Result
+
+        ExcludedByFilterFixture.oneTimeSetUpRunCount.Value |> shouldEqual 0
+        ExcludedByFilterFixture.oneTimeTearDownRunCount.Value |> shouldEqual 0
+
+        skipped |> Seq.toList |> shouldEqual [ nameof ExcludedByFilterFixture.someTest ]
+
+        let results = results |> List.exactlyOne
+        results.OtherFailures |> shouldBeEmpty
+        results.Failed |> shouldBeEmpty
+        results.Success |> shouldBeEmpty

--- a/WoofWare.NUnitTestRunner/WoofWare.NUnitTestRunner.Test/WoofWare.NUnitTestRunner.Test.fsproj
+++ b/WoofWare.NUnitTestRunner/WoofWare.NUnitTestRunner.Test/WoofWare.NUnitTestRunner.Test.fsproj
@@ -10,6 +10,7 @@
         <Compile Include="EmbeddedResource.fs" />
         <Compile Include="TestFilter.fs" />
         <Compile Include="TestList.fs" />
+        <Compile Include="TestRunFiltering.fs" />
         <Compile Include="TestSurface.fs" />
         <Compile Include="TestSynchronizationContext.fs" />
         <Compile Include="TestTrx.fs" />


### PR DESCRIPTION
## Summary

Review finding (P1): `OneTimeSetUp` ran before per-test filtering in `TestFixture.runOneFixture`, so a fixture with no selected tests was still initialized (and torn down), and a failing lifecycle method in an excluded fixture failed the whole filtered run.

Now the fixture's tests are filtered up front; when no tests are selected the fixture's lifecycle methods do not run at all, and the fixture doesn't occupy the parallel queue. `OnTestMemberSkipped` progress notifications are still emitted for filtered-out tests.

## Test

- New lib-level regression test: a fixture with deliberately failing `OneTimeSetUp`/`OneTimeTearDown` driven through `TestFixture.run` with an exclude-everything filter. Before the fix, the setup ran (and its failure appeared in `OtherFailures`); now nothing in the fixture executes.
- End-to-end check with the actual runner on `Consumer.dll`: `--filter 'FullyQualifiedName~TestAsync'` exited 1 before this fix (the excluded `TestSetUp` fixture's `OneTimeTearDown` assertion failed with no tests run); it exits 0 with the fix. The unfiltered run still exits 0.
- Full lib suite passes (41/41).

🤖 Generated with [Claude Code](https://claude.com/claude-code)