### PR TITLE
Await async OneTimeSetUp and OneTimeTearDown

### DIFF
--- a/Consumer/Consumer.fsproj
+++ b/Consumer/Consumer.fsproj
@@ -11,6 +11,7 @@
         <Compile Include="Inconclusive.fs" />
         <Compile Include="RunSubProcess.fs" />
         <Compile Include="TestAsync.fs" />
+        <Compile Include="TestAsyncSetUp.fs" />
         <Compile Include="TestExplicit.fs" />
         <Compile Include="TestNonParallel.fs" />
         <Compile Include="TestParallel.fs" />

--- a/Consumer/TestAsyncSetUp.fs
+++ b/Consumer/TestAsyncSetUp.fs
@@ -1,0 +1,61 @@
+namespace Consumer
+
+open System
+open System.Threading
+open System.Threading.Tasks
+open FsUnitTyped
+open NUnit.Framework
+
+[<TestFixture>]
+module TestAsyncOneTimeSetUp =
+
+    let setUpRunCount = ref 0
+    let tearDownRunCount = ref 0
+
+    [<OneTimeSetUp>]
+    let oneTimeSetUp () : Async<unit> =
+        async {
+            do! Async.Sleep (TimeSpan.FromMilliseconds 10.0)
+            Interlocked.Increment setUpRunCount |> ignore<int>
+        }
+
+    [<OneTimeTearDown>]
+    let oneTimeTearDown () : Async<unit> =
+        async {
+            do! Async.Sleep (TimeSpan.FromMilliseconds 10.0)
+
+            if Interlocked.Increment tearDownRunCount <> 1 then
+                failwith "one-time tear-down ran more than once"
+        }
+
+    [<Test>]
+    let ``async one-time setup has completed before tests run`` () =
+        setUpRunCount.Value |> shouldEqual 1
+        tearDownRunCount.Value |> shouldEqual 0
+
+[<TestFixture>]
+module TestTaskOneTimeSetUp =
+
+    let setUpRunCount = ref 0
+    let tearDownRunCount = ref 0
+
+    [<OneTimeSetUp>]
+    let oneTimeSetUp () : Task =
+        task {
+            do! Task.Delay (TimeSpan.FromMilliseconds 10.0)
+            Interlocked.Increment setUpRunCount |> ignore<int>
+        }
+
+    [<OneTimeTearDown>]
+    let oneTimeTearDown () : Task =
+        task {
+            do! Task.Delay (TimeSpan.FromMilliseconds 10.0)
+
+            if Interlocked.Increment tearDownRunCount <> 1 then
+                failwith "one-time tear-down ran more than once"
+        }
+
+    [<Test>]
+    let ``task one-time setup has completed before tests run`` () =
+        setUpRunCount.Value |> shouldEqual 1
+        tearDownRunCount.Value |> shouldEqual 0

--- a/WoofWare.NUnitTestRunner.Lib/TestFixture.fs
+++ b/WoofWare.NUnitTestRunner.Lib/TestFixture.fs
@@ -67,13 +67,25 @@ module TestFixture =
     /// Invoke this user-supplied method, awaiting its result if it returns a Task or an F# Async of unit.
     ///
     /// This function does not throw: failures of the user's code are reported in the Error case.
-    let private runUserMethod
+    let internal runUserMethod
         (containingObject : obj)
         (args : obj[])
         (method : MethodInfo)
         : Async<Result<unit, UserMethodFailure>>
         =
         async {
+            // Like NUnit, reject a result-bearing Task-returning method without running it: nothing would
+            // observe its result. (F#'s `task { }` of unit compiles to Task<unit>, which we accept.)
+            let declaredReturn = method.ReturnType
+
+            if
+                declaredReturn.IsGenericType
+                && declaredReturn.GetGenericTypeDefinition () = typedefof<Task<unit>>
+                && declaredReturn.GenericTypeArguments.[0].FullName <> "Microsoft.FSharp.Core.Unit"
+            then
+                return Error (UserMethodFailure.ReturnedNonUnit (method.Name, box declaredReturn))
+            else
+
             let result =
                 try
                     method.Invoke (containingObject, args) |> Ok
@@ -129,7 +141,9 @@ module TestFixture =
 
                         match res with
                         | Choice1Of2 () -> return Ok ()
-                        | Choice2Of2 _ -> return Error (UserMethodFailure.Threw (method.Name, started.Exception))
+                        // Report the caught exception, not `started.Exception`: a cancelled task has
+                        // Exception = null, whereas the caught value is a real TaskCanceledException.
+                        | Choice2Of2 e -> return Error (UserMethodFailure.Threw (method.Name, e))
                     | _ -> return Error (UserMethodFailure.ReturnedNonUnit (method.Name, ret))
                 else
                     return Error (UserMethodFailure.ReturnedNonUnit (method.Name, ret))

--- a/WoofWare.NUnitTestRunner.Lib/TestFixture.fs
+++ b/WoofWare.NUnitTestRunner.Lib/TestFixture.fs
@@ -64,6 +64,77 @@ type FixtureRunResults =
 [<RequireQualifiedAccess>]
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 module TestFixture =
+    /// Invoke this user-supplied method, awaiting its result if it returns a Task or an F# Async of unit.
+    ///
+    /// This function does not throw: failures of the user's code are reported in the Error case.
+    let private runUserMethod
+        (containingObject : obj)
+        (args : obj[])
+        (method : MethodInfo)
+        : Async<Result<unit, UserMethodFailure>>
+        =
+        async {
+            let result =
+                try
+                    method.Invoke (containingObject, args) |> Ok
+                with
+                | :? TargetInvocationException as e -> Error (UserMethodFailure.Threw (method.Name, e.InnerException))
+                | :? TargetParameterCountException ->
+                    UserMethodFailure.BadParameters (
+                        method.Name,
+                        method.GetParameters () |> Array.map (fun pm -> pm.ParameterType),
+                        args
+                    )
+                    |> Error
+
+            match result with
+            | Error e -> return Error e
+            | Ok result ->
+
+            match result with
+            | :? unit -> return Ok ()
+            | :? Task as result ->
+                let mutable exc = None
+
+                try
+                    do! Async.AwaitTask result
+                with e ->
+                    exc <- Some e
+
+                match exc with
+                | None -> return Ok ()
+                | Some e -> return Error (UserMethodFailure.Threw (method.Name, e))
+            // We'd like to do this type-test:
+            // | :? Async<unit> as result ->
+            // but instead we have to do all this reflective nonsense, because FSharpAsync is not part
+            // of the .NET runtime, so is instead in a different AssemblyLoadContext to us!
+            // It's in the user-code context, not ours.
+            | ret ->
+                let ty = ret.GetType ()
+
+                if ty.Namespace = "Microsoft.FSharp.Control" && ty.Name = "FSharpAsync`1" then
+                    match ty.GenericTypeArguments |> Array.map (fun t -> t.FullName) with
+                    | [| "Microsoft.FSharp.Core.Unit" |] ->
+                        let asyncModule = ty.Assembly.GetType ("Microsoft.FSharp.Control.FSharpAsync")
+                        // let catch = asyncModule.GetMethod("Catch").MakeGenericMethod [| ty.GenericTypeArguments.[0] |]
+                        // let caught = catch.Invoke ((null: obj), [| ret |])
+                        let startAsTask =
+                            asyncModule.GetMethod("StartAsTask").MakeGenericMethod [| ty.GenericTypeArguments.[0] |]
+
+                        let started =
+                            startAsTask.Invoke ((null : obj), [| ret ; (null : obj) ; (null : obj) |])
+                            |> unbox<Task>
+
+                        let! res = Async.AwaitTask started |> Async.Catch
+
+                        match res with
+                        | Choice1Of2 () -> return Ok ()
+                        | Choice2Of2 _ -> return Error (UserMethodFailure.Threw (method.Name, started.Exception))
+                    | _ -> return Error (UserMethodFailure.ReturnedNonUnit (method.Name, ret))
+                else
+                    return Error (UserMethodFailure.ReturnedNonUnit (method.Name, ret))
+        }
+
     /// It's possible for multiple things to fail about a test: e.g. the test failed and also the tear-down failed.
     ///
     /// This function does not throw.
@@ -88,83 +159,11 @@ module TestFixture =
             | [] -> async.Return (Ok ())
             | head :: rest ->
                 async {
-                    let result =
-                        try
-                            head.Invoke (containingObject, args) |> Ok
-                        with
-                        | :? TargetInvocationException as e ->
-                            Error (UserMethodFailure.Threw (head.Name, e.InnerException))
-                        | :? TargetParameterCountException ->
-                            UserMethodFailure.BadParameters (
-                                head.Name,
-                                head.GetParameters () |> Array.map (fun pm -> pm.ParameterType),
-                                args
-                            )
-                            |> Error
+                    let! result = runUserMethod containingObject args head
 
-                    let! ct = Async.CancellationToken
-
-                    let! result =
-                        match result with
-                        | Error e -> async.Return (Error (wrap e))
-                        | Ok result ->
-                            match result with
-                            | :? unit -> runMethods wrap rest args
-                            | :? Task as result ->
-                                async {
-                                    let mutable exc = None
-
-                                    try
-                                        do! Async.AwaitTask result
-                                    with e ->
-                                        exc <- Some e
-
-                                    match exc with
-                                    | None -> return! runMethods wrap rest args
-                                    | Some e -> return Error (UserMethodFailure.Threw (head.Name, e) |> wrap)
-                                }
-                            // We'd like to do this type-test:
-                            // | :? Async<unit> as result ->
-                            // but instead we have to do all this reflective nonsense, because FSharpAsync is not part
-                            // of the .NET runtime, so is instead in a different AssemblyLoadContext to us!
-                            // It's in the user-code context, not ours.
-                            | ret ->
-                                let ty = ret.GetType ()
-
-                                if ty.Namespace = "Microsoft.FSharp.Control" && ty.Name = "FSharpAsync`1" then
-                                    match ty.GenericTypeArguments |> Array.map (fun t -> t.FullName) with
-                                    | [| "Microsoft.FSharp.Core.Unit" |] ->
-                                        let asyncModule = ty.Assembly.GetType ("Microsoft.FSharp.Control.FSharpAsync")
-                                        // let catch = asyncModule.GetMethod("Catch").MakeGenericMethod [| ty.GenericTypeArguments.[0] |]
-                                        // let caught = catch.Invoke ((null: obj), [| ret |])
-                                        let startAsTask =
-                                            asyncModule.GetMethod("StartAsTask").MakeGenericMethod
-                                                [| ty.GenericTypeArguments.[0] |]
-
-                                        let started =
-                                            startAsTask.Invoke ((null : obj), [| ret ; (null : obj) ; (null : obj) |])
-                                            |> unbox<Task>
-
-                                        async {
-                                            let! res = Async.AwaitTask started |> Async.Catch
-
-                                            match res with
-                                            | Choice1Of2 () -> return! runMethods wrap rest args
-                                            | Choice2Of2 e ->
-                                                return
-                                                    Error (
-                                                        UserMethodFailure.Threw (head.Name, started.Exception) |> wrap
-                                                    )
-                                        }
-                                    | _ ->
-                                        UserMethodFailure.ReturnedNonUnit (head.Name, ret)
-                                        |> wrap
-                                        |> Error
-                                        |> async.Return
-                                else
-                                    async.Return (UserMethodFailure.ReturnedNonUnit (head.Name, ret) |> wrap |> Error)
-
-                    return result
+                    match result with
+                    | Ok () -> return! runMethods wrap rest args
+                    | Error e -> return Error (wrap e)
                 }
 
         async {
@@ -557,13 +556,9 @@ module TestFixture =
                             contexts.AsyncLocal.Value <- newOutputs
 
                             let result =
-                                try
-                                    match su.Invoke (containingObject, [||]) with
-                                    | :? unit -> None
-                                    | ret ->
-                                        Some (UserMethodFailure.ReturnedNonUnit (su.Name, ret), endMetadata newOutputs)
-                                with :? TargetInvocationException as e ->
-                                    Some (UserMethodFailure.Threw (su.Name, e.InnerException), endMetadata newOutputs)
+                                match runUserMethod containingObject [||] su |> Async.RunSynchronously with
+                                | Ok () -> None
+                                | Error err -> Some (err, endMetadata newOutputs)
 
                             contexts.AsyncLocal.Value <- oldValue
 
@@ -641,13 +636,9 @@ module TestFixture =
                             contexts.AsyncLocal.Value <- outputs
 
                             let result =
-                                try
-                                    match td.Invoke (containingObject, [||]) with
-                                    | :? unit -> None
-                                    | ret ->
-                                        Some (UserMethodFailure.ReturnedNonUnit (td.Name, ret), endMetadata outputs)
-                                with :? TargetInvocationException as e ->
-                                    Some (UserMethodFailure.Threw (td.Name, e.InnerException), endMetadata outputs)
+                                match runUserMethod containingObject [||] td |> Async.RunSynchronously with
+                                | Ok () -> None
+                                | Error err -> Some (err, endMetadata outputs)
 
                             contexts.AsyncLocal.Value <- oldValue
 

--- a/WoofWare.NUnitTestRunner/WoofWare.NUnitTestRunner.Test/TestAsyncLifecycle.fs
+++ b/WoofWare.NUnitTestRunner/WoofWare.NUnitTestRunner.Test/TestAsyncLifecycle.fs
@@ -1,0 +1,135 @@
+namespace WoofWare.NUnitTestRunner.Test
+
+open System
+open System.Threading
+open System.Threading.Tasks
+open NUnit.Framework
+open FsUnitTyped
+open WoofWare.NUnitTestRunner
+
+/// A module deliberately carrying no NUnit attributes: NUnit must not discover it, because its members
+/// misbehave. Instead, TestAsyncLifecycle drives it through TestFixture.run.
+module ResultBearingFixture =
+    /// Lets us name this module's compiled Type via typeof.
+    type Marker = class end
+
+    let setUpBodyRuns = ref 0
+
+    let taskOfIntSetUp () : Task<int> =
+        Interlocked.Increment setUpBodyRuns |> ignore<int>
+        Task.FromResult 3
+
+    let taskOfIntTest () : Task<int> = Task.FromResult 3
+
+    let taskOfUnitTest () = task { return () }
+
+    let someTest () : unit = ()
+
+    let cancellingTest () : Async<unit> =
+        async {
+            // This cancels the default token, which is what the runner hands to StartAsTask; our own task
+            // therefore completes through its cancellation continuation rather than by throwing.
+            Async.CancelDefaultToken ()
+            do! Async.Sleep 1000
+        }
+
+[<TestFixture>]
+module TestAsyncLifecycle =
+
+    let private noOpProgress =
+        { new ITestProgress with
+            member _.OnTestFixtureStart _ _ = ()
+            member _.OnTestFixtureSkipped _ _ = ()
+            member _.OnTestMemberStart _ = ()
+            member _.OnTestFailed _ _ = ()
+            member _.OnTestMemberFinished _ = ()
+            member _.OnTestMemberSkipped _ = ()
+        }
+
+    let private moduleType = typeof<ResultBearingFixture.Marker>.DeclaringType
+
+    let private makeTest (name : string) : SingleTestMethod =
+        {
+            Method = moduleType.GetMethod name
+            Kind = TestKind.Single
+            Modifiers = []
+            Categories = []
+            Repeat = None
+            Combinatorial = None
+            Parallelize = None
+        }
+
+    let private runFixture (fixture : TestFixture) : FixtureRunResults =
+        use contexts = TestContexts.Empty ()
+        use par = new ParallelQueue (None, None)
+
+        let run = TestFixture.run contexts par noOpProgress (fun _ _ -> true) fixture
+
+        if not (run.Wait (TimeSpan.FromSeconds 60.0)) then
+            failwith "test run failed to terminate"
+
+        run.Result |> List.exactlyOne
+
+    [<Test>]
+    let ``A one-time setup returning Task of int is rejected without being run`` () =
+        let fixture =
+            { TestFixture.Empty moduleType None [] [] with
+                OneTimeSetUp = Some (moduleType.GetMethod (nameof ResultBearingFixture.taskOfIntSetUp))
+                Tests = [ makeTest (nameof ResultBearingFixture.someTest) ]
+            }
+
+        let results = runFixture fixture
+
+        results.Success |> shouldBeEmpty
+        results.Failed |> shouldBeEmpty
+
+        match results.OtherFailures with
+        | [ UserMethodFailure.ReturnedNonUnit _, _ ] -> ()
+        | other -> failwith $"Expected exactly one ReturnedNonUnit failure, got: %O{other}"
+
+        // NUnit rejects such a method without executing it, and so do we.
+        ResultBearingFixture.setUpBodyRuns.Value |> shouldEqual 0
+
+    [<Test>]
+    let ``A test returning Task of int is rejected; a test returning Task of unit is accepted`` () =
+        let fixture =
+            { TestFixture.Empty moduleType None [] [] with
+                Tests =
+                    [
+                        makeTest (nameof ResultBearingFixture.taskOfIntTest)
+                        makeTest (nameof ResultBearingFixture.taskOfUnitTest)
+                    ]
+            }
+
+        let results = runFixture fixture
+
+        results.OtherFailures |> shouldBeEmpty
+
+        results.Success
+        |> List.map (fun (test, result, _) -> test.Name, result)
+        |> shouldEqual [ nameof ResultBearingFixture.taskOfUnitTest, TestMemberSuccess.Ok ]
+
+        match results.Failed with
+        | [ TestMemberFailure.Failed [ TestFailure.TestFailed (UserMethodFailure.ReturnedNonUnit _) ], _ ] -> ()
+        | other -> failwith $"Expected exactly one ReturnedNonUnit test failure, got: %O{other}"
+
+    [<Test>]
+    let ``A user async which cancels itself is reported as a real exception`` () =
+        // We can't drive this through TestFixture.run: cancelling the default token also cancels the
+        // runner's own async machinery (which the runner starts without an explicit token), deadlocking
+        // the run. So test the invocation helper directly, running it under a token which the user's
+        // cancellation cannot touch.
+        let method = moduleType.GetMethod (nameof ResultBearingFixture.cancellingTest)
+
+        let result =
+            Async.RunSynchronously (
+                TestFixture.runUserMethod (null : obj) [||] method,
+                cancellationToken = CancellationToken.None
+            )
+
+        match result with
+        | Error (UserMethodFailure.Threw (_, exc)) ->
+            // A cancelled task has Exception = null; the failure must carry the real
+            // TaskCanceledException, or downstream report generation dereferences null and crashes.
+            isNull (box exc) |> shouldEqual false
+        | other -> failwith $"Expected a Threw failure, got: %O{other}"

--- a/WoofWare.NUnitTestRunner/WoofWare.NUnitTestRunner.Test/WoofWare.NUnitTestRunner.Test.fsproj
+++ b/WoofWare.NUnitTestRunner/WoofWare.NUnitTestRunner.Test/WoofWare.NUnitTestRunner.Test.fsproj
@@ -10,6 +10,7 @@
         <Compile Include="EmbeddedResource.fs" />
         <Compile Include="TestFilter.fs" />
         <Compile Include="TestFixtureRunner.fs" />
+        <Compile Include="TestAsyncLifecycle.fs" />
         <Compile Include="TestList.fs" />
         <Compile Include="TestRunFiltering.fs" />
         <Compile Include="TestSurface.fs" />


### PR DESCRIPTION
## Summary

Review finding (P1): unlike per-test lifecycle invocation, `OneTimeSetUp`/`OneTimeTearDown` did not await `Task` or F# `Async<unit>` results. A valid async one-time setup was immediately recorded as `ReturnedNonUnit`, preventing its fixture's tests from running; teardown had the same defect.

The async-aware invocation logic previously embedded in `runOne`'s `runMethods` is extracted into a shared `runUserMethod`, which the one-time setup/teardown paths now use as well (run synchronously to completion before tests start / the fixture completes, matching the previous ordering guarantees). A side benefit: a one-time method with a parameter-count mismatch is now reported as `BadParameters` instead of only `TargetInvocationException` being handled.

## Test

Added two Consumer fixtures: one with `Async<unit>`-returning `OneTimeSetUp`/`OneTimeTearDown`, one with `Task`-returning ones, each asserting the setup completed before its test runs.

- `dotnet test Consumer` (real NUnit) accepts both and passes (395 passed, 2 skipped), so the expectations match NUnit semantics.
- Self-run before the fix: exit code 1, the two fixtures' tests never ran.
- Self-run after the fix: exit code 0, both tests run and pass.
- Full CI-equivalent suite passes (lib 40/40, Consumer 395/397 with the usual 2 explicit skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)