### PR TITLE
Unpack object-array TestCaseSource rows as argument lists

### DIFF
--- a/Consumer/TestCaseData.fs
+++ b/Consumer/TestCaseData.fs
@@ -35,6 +35,17 @@ module TestCaseData =
     [<TestCaseSource(nameof optionalRaw)>]
     let ``Consume options, raw`` (s : string option) : unit = s |> shouldEqual s
 
+    let objectArraysSeen = ResizeArray ()
+
+    let objectArrayRawData = [ 3, "hi" ; -10, "bye" ]
+
+    let objectArraySource : obj[] list =
+        objectArrayRawData |> List.map (fun (i, s) -> [| box i ; box s |])
+
+    [<TestCaseSource(nameof objectArraySource)>]
+    let ``Consume object array rows`` (i : int, s : string) =
+        lock objectArraysSeen (fun () -> objectArraysSeen.Add (i, s))
+
     [<TestCase(30, 15, 44, false)>]
     let bug66 (i : int, j : int, k : int, l : bool) =
         i |> shouldEqual 30
@@ -53,3 +64,8 @@ module TestCaseData =
         |> Seq.toList
         |> List.sortBy (fun (a, _, _) -> a)
         |> shouldEqual ((dataSourceRaw @ dataSource2Raw) |> List.sortBy (fun (a, _, _) -> a))
+
+        objectArraysSeen
+        |> Seq.toList
+        |> List.sortBy fst
+        |> shouldEqual (objectArrayRawData |> List.sortBy fst)

--- a/WoofWare.NUnitTestRunner.Lib/TestFixture.fs
+++ b/WoofWare.NUnitTestRunner.Lib/TestFixture.fs
@@ -408,6 +408,10 @@ module TestFixture =
                                     | :? Tuple<obj, obj> as (a, b) -> [| a ; b |]
                                     | :? Tuple<obj, obj, obj> as (a, b, c) -> [| a ; b ; c |]
                                     | :? Tuple<obj, obj, obj, obj> as (a, b, c, d) -> [| a ; b ; c ; d |]
+                                    // NUnit convention: a source row which is an object array is the argument
+                                    // list itself. (Array covariance means this also catches e.g. string[],
+                                    // exactly as NUnit's own `is object[]` test does.)
+                                    | :? (obj[]) as args -> args
                                     | arg ->
                                         let argTy = arg.GetType ()
 


### PR DESCRIPTION
## Summary

Review finding (P1): a `TestCaseSource` row whose runtime type is `object[]` fell through to the `[| arg |]` single-argument case, so the conventional `IEnumerable<object[]>` source shape reported a parameter-count mismatch for every multi-argument test. NUnit treats an `object[]` row as the argument list itself (via an `is object[]` test, which through array covariance also unpacks e.g. `string[]` rows); this change matches that.

## Test

Added a `Consume object array rows` test to the Consumer `TestCaseData` fixture using an `obj[] list` source with two-argument rows, with the usual `OneTimeTearDown` assertion that every row was seen.

- Real NUnit accepts and passes it (`dotnet test Consumer`: 395 passed, 2 skipped), confirming the expectation matches NUnit semantics.
- Self-run before the fix: exit 1 with `parameter count mismatch. Expected: (Int32, String) (2 params). Actual: (System.Object[]) (1 params)` for every row — exactly the reviewed failure.
- Self-run after the fix: exit 0, both rows executed.
- Lib suite passes (40/40).

🤖 Generated with [Claude Code](https://claude.com/claude-code)