### PR TITLE
Make TrxReport.parse return Error on malformed input

### DIFF
--- a/WoofWare.NUnitTestRunner.Lib/TrxReport.fs
+++ b/WoofWare.NUnitTestRunner.Lib/TrxReport.fs
@@ -641,7 +641,10 @@ type TrxTestMethod =
         let adapterTypeName =
             match attrs.TryGetValue "adapterTypeName" with
             | false, _ -> Error "Expected adapterTypeName attribute"
-            | true, v -> Uri v |> Ok
+            | true, v ->
+                match Uri.TryCreate (v, UriKind.Absolute) with
+                | true, uri -> Ok uri
+                | false, _ -> Error $"Could not parse adapterTypeName attribute as a URI: %s{v}"
 
         let className =
             match attrs.TryGetValue "className" with
@@ -1772,7 +1775,17 @@ module TrxReport =
     /// Parse the report. May instead return a human-readable description of why we couldn't parse.
     let parse (s : string) : Result<TrxReport, string> =
         let node = XmlDocument ()
-        node.LoadXml s
+
+        let loaded =
+            try
+                node.LoadXml s
+                Ok ()
+            with :? XmlException as e ->
+                Error $"Could not parse input as XML: %s{e.Message}"
+
+        match loaded with
+        | Error e -> Error e
+        | Ok () ->
 
         match node with
         | NodeWithNamedChild "TestRun" node -> TrxReport.ofXml node

--- a/WoofWare.NUnitTestRunner/WoofWare.NUnitTestRunner.Test/TestTrx.fs
+++ b/WoofWare.NUnitTestRunner/WoofWare.NUnitTestRunner.Test/TestTrx.fs
@@ -1,6 +1,7 @@
 namespace WoofWare.NUnitTestRunner.Test
 
 open System
+open FsCheck
 open WoofWare.NUnitTestRunner
 open NUnit.Framework
 open FsUnitTyped
@@ -234,3 +235,27 @@ NUnit Adapter 4.5.0.0: Test execution complete
             afterwards.OuterXml |> TrxReport.parse |> Result.get |> Option.get
 
         andParsedAgain |> reportShouldEqual original
+
+    [<Test>]
+    let ``Malformed XML produces an Error, not an exception`` () =
+        match TrxReport.parse "<" with
+        | Error _ -> ()
+        | Ok report -> failwith $"Unexpectedly parsed malformed XML: %O{report}"
+
+    [<Test>]
+    let ``A malformed adapterTypeName URI produces an Error, not an exception`` () =
+        let mangled =
+            (EmbeddedResource.read "Example1.trx").Replace ("executor://nunit3testexecutor/", "not a valid uri")
+
+        match TrxReport.parse mangled with
+        | Error _ -> ()
+        | Ok report -> failwith $"Unexpectedly parsed report with malformed URI: %O{report}"
+
+    [<Test>]
+    let ``Parsing arbitrary input does not throw`` () =
+        let property (s : string) =
+            match s with
+            | null -> ()
+            | s -> TrxReport.parse s |> ignore<Result<TrxReport, string>>
+
+        Check.QuickThrowOnFailure property


### PR DESCRIPTION
## Summary

Review finding (P2): `TrxReport.parse` is `Result`-returning, but `XmlDocument.LoadXml` sat outside any exception handling, so `TrxReport.parse "<"` raised `XmlException` instead of producing `Error`. The review also noted malformed URI attributes throw later: `TrxTestMethod.ofXml` constructed `Uri` directly from the `adapterTypeName` attribute, raising `UriFormatException`.

Both boundaries now produce `Error` with a human-readable message: `LoadXml` is wrapped, and the URI parse uses `Uri.TryCreate` (with `UriKind.Absolute`, matching what the previous `Uri` constructor accepted).

## Test

Three new tests in `TestTrx`, all failing before the fix and passing after:
- `parse "<"` returns `Error` (the review's repro).
- `Example1.trx` with its `adapterTypeName` replaced by a non-URI returns `Error`.
- FsCheck property: `parse` never throws on arbitrary strings.

Full lib suite passes (43/43), including the existing round-trip tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)