### PR TITLE
Report each case of an individually Explicit or Ignored test

### DIFF
--- a/WoofWare.NUnitTestRunner.Lib/TestFixture.fs
+++ b/WoofWare.NUnitTestRunner.Lib/TestFixture.fs
@@ -375,6 +375,25 @@ module TestFixture =
                 ]
                 |> Ok
 
+    /// The individual test cases of a test which is not going to be run, with human-readable names:
+    /// one entry per case per repeat, where repeats of a case share its identifier (exactly as on the
+    /// running path). Enumeration runs user TestCaseSource code, which may fail arbitrarily; a skipped
+    /// test must never fail the run, so in that case fall back to reporting the bare test method.
+    let private skippedTestCases (test : SingleTestMethod) : (Guid * string) list =
+        let cases =
+            try
+                match getIndividualTestCases test with
+                | Ok cases ->
+                    cases
+                    |> List.map (fun (caseId, args) -> caseId, individualTestName test.Method args)
+                | Error _ -> [ Guid.NewGuid (), test.Name ]
+            with _ ->
+                [ Guid.NewGuid (), test.Name ]
+
+        let count = test.Repeat |> Option.defaultValue 1
+
+        Seq.init count (fun _ -> cases) |> Seq.concat |> Seq.toList
+
     /// This method should never throw: it only throws if there's a critical logic error in the runner.
     /// Exceptions from the units under test are wrapped up and passed out.
     let private runTestsFromMember
@@ -424,22 +443,27 @@ module TestFixture =
 
         match resultPreRun with
         | Some result ->
-            let failureMetadata =
-                {
-                    Total = TimeSpan.Zero
-                    Start = DateTimeOffset.Now
-                    End = DateTimeOffset.Now
-                    ComputerName = Environment.MachineName
-                    ExecutionId = Guid.NewGuid ()
-                    // No need to keep these test GUIDs stable: no point trying to run an explicit test multiple times.
-                    TestId = Guid.NewGuid ()
-                    TestName = test.Name
-                    ClassName = test.Method.DeclaringType.FullName
-                    StdErr = None
-                    StdOut = None
-                }
+            // Like NUnit, report each individual test case of the skipped test.
+            let now = DateTimeOffset.Now
 
-            (Ok result, failureMetadata) |> Task.FromResult |> List.singleton
+            skippedTestCases test
+            |> List.map (fun (caseId, name) ->
+                let metadata =
+                    {
+                        Total = TimeSpan.Zero
+                        Start = now
+                        End = now
+                        ComputerName = Environment.MachineName
+                        ExecutionId = Guid.NewGuid ()
+                        TestId = caseId
+                        TestName = name
+                        ClassName = test.Method.DeclaringType.FullName
+                        StdErr = None
+                        StdOut = None
+                    }
+
+                (Ok result, metadata) |> Task.FromResult
+            )
         | None ->
 
         let individualTests = getIndividualTestCases test
@@ -875,24 +899,8 @@ module TestFixture =
                 let skipped =
                     testsToReport
                     |> List.collect (fun test ->
-                        let cases =
-                            // Enumeration runs user TestCaseSource code, which may fail arbitrarily; a
-                            // skipped fixture must never fail the run, so fall back to reporting the bare
-                            // test method.
-                            try
-                                match getIndividualTestCases test with
-                                | Ok cases ->
-                                    cases
-                                    |> List.map (fun (caseId, args) -> caseId, individualTestName test.Method args)
-                                | Error _ -> [ Guid.NewGuid (), test.Name ]
-                            with _ ->
-                                [ Guid.NewGuid (), test.Name ]
-
-                        let count = test.Repeat |> Option.defaultValue 1
-
-                        Seq.init count (fun _ -> cases)
-                        |> Seq.concat
-                        |> Seq.map (fun (caseId, name) ->
+                        skippedTestCases test
+                        |> List.map (fun (caseId, name) ->
                             let metadata =
                                 {
                                     Total = TimeSpan.Zero
@@ -900,7 +908,6 @@ module TestFixture =
                                     End = now
                                     ComputerName = Environment.MachineName
                                     ExecutionId = Guid.NewGuid ()
-                                    // Repeats of a case share its identifier, exactly as on the running path.
                                     TestId = caseId
                                     TestName = name
                                     ClassName = test.Method.DeclaringType.FullName
@@ -910,7 +917,6 @@ module TestFixture =
 
                             test, result, metadata
                         )
-                        |> Seq.toList
                     )
 
                 {

--- a/WoofWare.NUnitTestRunner/WoofWare.NUnitTestRunner.Test/TestSkippedFixtures.fs
+++ b/WoofWare.NUnitTestRunner/WoofWare.NUnitTestRunner.Test/TestSkippedFixtures.fs
@@ -185,6 +185,39 @@ module TestSkippedFixtures =
             ]
 
     [<Test>]
+    let ``An individually ignored data-driven test reports each of its cases`` () =
+        let moduleType = typeof<SkippedFixture.Marker>.DeclaringType
+
+        let fixture =
+            { TestFixture.Empty moduleType None [] [] with
+                Tests =
+                    [
+                        { makeTestOfKind (TestKind.Data [ [ box 1 ] ; [ box 2 ] ]) (nameof SkippedFixture.dataTest) with
+                            Modifiers = [ Modifier.Ignored (Some "broken") ]
+                        }
+                    ]
+            }
+
+        use contexts = TestContexts.Empty ()
+        use par = new ParallelQueue (None, None)
+
+        let results =
+            (TestFixture.run contexts par noOpProgress (fun _ _ -> true) fixture).Result
+
+        let results = results |> List.exactlyOne
+        results.Failed |> shouldBeEmpty
+        results.OtherFailures |> shouldBeEmpty
+
+        results.Success
+        |> List.map (fun (_, result, metadata) -> metadata.TestName, result)
+        |> List.sortBy fst
+        |> shouldEqual
+            [
+                "dataTest(1)", TestMemberSuccess.Ignored (Some "broken")
+                "dataTest(2)", TestMemberSuccess.Ignored (Some "broken")
+            ]
+
+    [<Test>]
     let ``A skipped parameterised fixture reports each of its tests once per parameter set`` () =
         let fixture =
             { makeFixture (Modifier.Explicit None) with


### PR DESCRIPTION
## Summary

Follow-up to #445, fixing the sibling divergence noted there: a test *method* carrying its own `[<Explicit>]`/`[<Ignore>]` modifier reported a single result entry, but NUnit reports each individual test case. Verified against real NUnit 4.6.1: an `[<Ignore>]`d method with two `TestCase`s (or a two-row `TestCaseSource`) shows two individually-named skipped tests.

The skipped-case enumeration introduced in #445 (per-case per-repeat names via `getIndividualTestCases`, with the fall-back-to-bare-method guard around user source code) is extracted into a shared `skippedTestCases` and used by both the skipped-fixture path and the per-test `resultPreRun` path.

**Stacked on #445** (`fix-skipped-fixture-results`) — it needs the enumeration extracted there. Merge #445 first; I'll rebase this onto main afterwards if needed.

## Test

New lib-level test: an individually-Ignored `TestKind.Data` method with two cases must report `dataTest(1)`/`dataTest(2)`, both Ignored. Failed before (single `dataTest` entry), passes after. Full lib suite 53/53; Consumer self-run unchanged (exit 0, total=402, notExecuted=3 — Consumer's individually-skipped tests are no-arg, so counters are rightly unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)