### PR TITLE
Run the runner's asyncs on a runner-owned cancellation token

### DIFF
--- a/WoofWare.NUnitTestRunner.Lib/ParallelQueue.fs
+++ b/WoofWare.NUnitTestRunner.Lib/ParallelQueue.fs
@@ -130,7 +130,6 @@ type private MailboxState =
 
 /// Run some things in parallel.
 /// TODO: actually implement the parallelism! Right now this just runs everything serially.
-/// TODO: consume the cancellation token
 type ParallelQueue
     (parallelism : int option, _scope : Parallelizable<AssemblyParallelScope> option, ?ct : CancellationToken)
     =
@@ -138,6 +137,14 @@ type ParallelQueue
         match parallelism with
         | None -> max (Environment.ProcessorCount / 2) 2
         | Some p -> p
+
+    // The runner's asyncs must never run on the shared default cancellation token: user code can cancel
+    // that token (Async.CancelDefaultToken), which would silently kill the runner's machinery and
+    // deadlock the run. Everything we start runs on this source instead.
+    let cts =
+        match ct with
+        | Some ct -> CancellationTokenSource.CreateLinkedTokenSource ct
+        | None -> new CancellationTokenSource ()
 
     let rec processTask (state : MailboxState) (m : MailboxProcessor<MailboxMessage>) =
         async {
@@ -338,7 +345,7 @@ type ParallelQueue
                                             m.Post MailboxMessage.Reconcile
                                             rc.Reply result
                                         }
-                                        |> Async.StartImmediate
+                                        |> fun comp -> Async.StartImmediate (comp, cancellationToken = cts.Token)
                                     ),
                                     ()
                                 )
@@ -359,8 +366,14 @@ type ParallelQueue
                 return! processTask state m
         }
 
-    let mb = new MailboxProcessor<_> (processTask MailboxState.Idle)
+    let mb =
+        new MailboxProcessor<_> (processTask MailboxState.Idle, cancellationToken = cts.Token)
+
     do mb.Start ()
+
+    /// The token on which all of this queue's asyncs run; cancelled only when the token supplied at
+    /// construction (if any) is cancelled. Run runner-side work on this, never on the default token.
+    member internal _.CancellationToken : CancellationToken = cts.Token
 
     /// Request to run the given async action, freely in parallel with other running tests.
     /// The resulting Task will return when the action has completed.
@@ -376,7 +389,7 @@ type ParallelQueue
             let! result =
                 (fun rc -> MailboxMessage.RunTestAsync (parent, scope, AsyncThunkCrate.make action rc, ec))
                 |> mb.PostAndAsyncReply
-                |> Async.StartAsTask
+                |> fun comp -> Async.StartAsTask (comp, cancellationToken = cts.Token)
 
             match result with
             | Ok o -> return o
@@ -399,7 +412,7 @@ type ParallelQueue
     member _.StartTestFixture (tf : TestFixture) : Task<TestFixtureRunningToken> =
         fun rc -> MailboxMessage.BeginTestFixture (tf, rc)
         |> mb.PostAndAsyncReply
-        |> Async.StartAsTask
+        |> fun comp -> Async.StartAsTask (comp, cancellationToken = cts.Token)
 
     /// Run the given one-time setup for the test fixture.
     member _.RunTestSetup (TestFixtureRunningToken parent) (action : unit -> 'a) : ('a * TestFixtureSetupToken) Task =
@@ -424,6 +437,7 @@ type ParallelQueue
                     )
                 )
                 |> mb.PostAndAsyncReply
+                |> fun comp -> Async.StartAsTask (comp, cancellationToken = cts.Token)
 
             match response with
             | Ok response -> return response, TestFixtureSetupToken parent
@@ -457,6 +471,7 @@ type ParallelQueue
                     )
                 )
                 |> mb.PostAndAsyncReply
+                |> fun comp -> Async.StartAsTask (comp, cancellationToken = cts.Token)
 
             match response with
             | Ok response -> return response, TestFixtureTearDownToken parent
@@ -468,10 +483,11 @@ type ParallelQueue
     member _.EndTestFixture (tf : TestFixtureTearDownToken) : Task<unit> =
         (fun rc -> MailboxMessage.EndTestFixture (tf, rc))
         |> mb.PostAndAsyncReply
-        |> Async.StartAsTask
+        |> fun comp -> Async.StartAsTask (comp, cancellationToken = cts.Token)
 
     interface IDisposable with
         member _.Dispose () =
             // Still race conditions, of course: people could still be submitting after we finish the sync.
             mb.PostAndReply MailboxMessage.Quit
             (mb :> IDisposable).Dispose ()
+            cts.Dispose ()

--- a/WoofWare.NUnitTestRunner.Lib/TestFixture.fs
+++ b/WoofWare.NUnitTestRunner.Lib/TestFixture.fs
@@ -65,9 +65,11 @@ type FixtureRunResults =
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 module TestFixture =
     /// Invoke this user-supplied method, awaiting its result if it returns a Task or an F# Async of unit.
+    /// An F# Async result is started with the given cancellation token.
     ///
     /// This function does not throw: failures of the user's code are reported in the Error case.
     let internal runUserMethod
+        (ct : CancellationToken)
         (containingObject : obj)
         (args : obj[])
         (method : MethodInfo)
@@ -133,8 +135,16 @@ module TestFixture =
                         let startAsTask =
                             asyncModule.GetMethod("StartAsTask").MakeGenericMethod [| ty.GenericTypeArguments.[0] |]
 
+                        // Pass our token explicitly: with none supplied, StartAsTask would run the user's
+                        // async on the process-wide default token, which user code can cancel out from
+                        // under us. The option must be built reflectively because it's the FSharpOption
+                        // of the user's FSharp.Core, not ours.
+                        let cancellationToken =
+                            let optionTy = startAsTask.GetParameters().[2].ParameterType
+                            Activator.CreateInstance (optionTy, [| box ct |])
+
                         let started =
-                            startAsTask.Invoke ((null : obj), [| ret ; (null : obj) ; (null : obj) |])
+                            startAsTask.Invoke ((null : obj), [| ret ; (null : obj) ; cancellationToken |])
                             |> unbox<Task>
 
                         let! res = Async.AwaitTask started |> Async.Catch
@@ -153,6 +163,7 @@ module TestFixture =
     ///
     /// This function does not throw.
     let private runOne
+        (ct : CancellationToken)
         (outputId : OutputStreamId)
         (contexts : TestContexts)
         (setUp : MethodInfo list)
@@ -173,7 +184,7 @@ module TestFixture =
             | [] -> async.Return (Ok ())
             | head :: rest ->
                 async {
-                    let! result = runUserMethod containingObject args head
+                    let! result = runUserMethod ct containingObject args head
 
                     match result with
                     | Ok () -> return! runMethods wrap rest args
@@ -482,7 +493,16 @@ module TestFixture =
                         contexts.AsyncLocal.Value <- outputId
 
                         let! result, meta =
-                            runOne outputId contexts setUp tearDown testGuid test.Method containingObject args
+                            runOne
+                                par.CancellationToken
+                                outputId
+                                contexts
+                                setUp
+                                tearDown
+                                testGuid
+                                test.Method
+                                containingObject
+                                args
 
                         contexts.AsyncLocal.Value <- oldValue
                         progress.OnTestMemberFinished test.Name
@@ -570,7 +590,12 @@ module TestFixture =
                             contexts.AsyncLocal.Value <- newOutputs
 
                             let result =
-                                match runUserMethod containingObject [||] su |> Async.RunSynchronously with
+                                match
+                                    Async.RunSynchronously (
+                                        runUserMethod par.CancellationToken containingObject [||] su,
+                                        cancellationToken = par.CancellationToken
+                                    )
+                                with
                                 | Ok () -> None
                                 | Error err -> Some (err, endMetadata newOutputs)
 
@@ -650,7 +675,12 @@ module TestFixture =
                             contexts.AsyncLocal.Value <- outputs
 
                             let result =
-                                match runUserMethod containingObject [||] td |> Async.RunSynchronously with
+                                match
+                                    Async.RunSynchronously (
+                                        runUserMethod par.CancellationToken containingObject [||] td,
+                                        cancellationToken = par.CancellationToken
+                                    )
+                                with
                                 | Ok () -> None
                                 | Error err -> Some (err, endMetadata outputs)
 

--- a/WoofWare.NUnitTestRunner/WoofWare.NUnitTestRunner.Test/TestAsyncLifecycle.fs
+++ b/WoofWare.NUnitTestRunner/WoofWare.NUnitTestRunner.Test/TestAsyncLifecycle.fs
@@ -27,11 +27,13 @@ module ResultBearingFixture =
 
     let cancellingTest () : Async<unit> =
         async {
-            // This cancels the default token, which is what the runner hands to StartAsTask; our own task
-            // therefore completes through its cancellation continuation rather than by throwing.
+            // Hostile user code: this cancels the process-wide default token. The runner must not have
+            // anything running on that token.
             Async.CancelDefaultToken ()
             do! Async.Sleep 1000
         }
+
+    let sleepingTest () : Async<unit> = async { do! Async.Sleep 10000 }
 
 [<TestFixture>]
 module TestAsyncLifecycle =
@@ -114,16 +116,33 @@ module TestAsyncLifecycle =
         | other -> failwith $"Expected exactly one ReturnedNonUnit test failure, got: %O{other}"
 
     [<Test>]
-    let ``A user async which cancels itself is reported as a real exception`` () =
-        // We can't drive this through TestFixture.run: cancelling the default token also cancels the
-        // runner's own async machinery (which the runner starts without an explicit token), deadlocking
-        // the run. So test the invocation helper directly, running it under a token which the user's
-        // cancellation cannot touch.
-        let method = moduleType.GetMethod (nameof ResultBearingFixture.cancellingTest)
+    let ``Cancelling the default token from user code does not deadlock the runner`` () =
+        let fixture =
+            { TestFixture.Empty moduleType None [] [] with
+                Tests = [ makeTest (nameof ResultBearingFixture.cancellingTest) ]
+            }
+
+        let results = runFixture fixture
+
+        results.OtherFailures |> shouldBeEmpty
+        results.Failed |> shouldBeEmpty
+
+        // The runner's own machinery must not be running on the token the user cancelled, so the user's
+        // async just runs to completion.
+        results.Success
+        |> List.map (fun (test, result, _) -> test.Name, result)
+        |> shouldEqual [ nameof ResultBearingFixture.cancellingTest, TestMemberSuccess.Ok ]
+
+    [<Test>]
+    let ``A cancelled user async is reported as a real exception`` () =
+        let method = moduleType.GetMethod (nameof ResultBearingFixture.sleepingTest)
+
+        use cts = new CancellationTokenSource ()
+        cts.CancelAfter (TimeSpan.FromMilliseconds 50.0)
 
         let result =
             Async.RunSynchronously (
-                TestFixture.runUserMethod (null : obj) [||] method,
+                TestFixture.runUserMethod cts.Token (null : obj) [||] method,
                 cancellationToken = CancellationToken.None
             )
 


### PR DESCRIPTION
## Summary

Follow-up to the deadlock discovered while testing #443's cancellation fix: every internal async the runner starts (the `ParallelQueue` `MailboxProcessor`, the `StartImmediate` dispatch chains, the `StartAsTask`/`PostAndAsyncReply` conversions) implicitly ran on the process-wide **default** cancellation token — and so did the tasks we start for users' F# `Async` test bodies. User code calling `Async.CancelDefaultToken ()` therefore killed the runner's own machinery: mailbox replies were never delivered, the run deadlocked short of its 2-hour timeout, and even `ParallelQueue`'s `Dispose` hung on the dead mailbox.

`ParallelQueue` now owns a `CancellationTokenSource`, linked to the `CancellationToken` its constructor already accepted but never consumed (the `TODO: consume the cancellation token` comment). Everything the queue starts runs on that token, exposed internally as `ParallelQueue.CancellationToken`; `TestFixture` uses it for `runOne`, the one-time lifecycle `RunSynchronously` calls, and — reflectively, since the option must be built in the user's `FSharp.Core` — the `StartAsTask` that runs users' `Async<unit>` bodies. Cancelling the constructor-supplied token remains the (future) cooperative-shutdown path.

## Test

New end-to-end test: a test body that calls `Async.CancelDefaultToken ()` then sleeps. Before this change, that run deadlocked — observed as a 300-second no-verdict hang, process killed manually. After, the run completes in ~1s and the user's test simply passes, since nothing it can reach is on the default token anymore.

The direct `runUserMethod` cancellation test from #443 is updated to match the new reality: cancellation of a user async now comes from the token the runner passes (externally cancelled in the test), and is still reported as a real `TaskCanceledException` rather than a null.

Full lib suite 49/49; Consumer self-run exit 0.

**Stacked on #443** (`fix-async-onetime-lifecycle`): it modifies `runUserMethod`, which is introduced there. Merge #443 first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)